### PR TITLE
fix: add proper support for typealiases

### DIFF
--- a/compiler-core/src/main/java/toothpick/compiler/common/ToothpickProcessor.kt
+++ b/compiler-core/src/main/java/toothpick/compiler/common/ToothpickProcessor.kt
@@ -66,7 +66,8 @@ abstract class ToothpickProcessor(
     }
 
     protected fun KSType.isValidInjectedType(node: KSNode, qualifiedName: String?): Boolean {
-        return if (!isValidInjectedClassKind() && !isTypeAlias()) false
+        return if (isError) false
+        else if (!isValidInjectedClassKind() && !isTypeAlias()) false
         else !isProviderOrLazy() || isValidProviderOrLazy(node, qualifiedName)
     }
 

--- a/compiler-core/src/main/java/toothpick/compiler/common/ToothpickProcessor.kt
+++ b/compiler-core/src/main/java/toothpick/compiler/common/ToothpickProcessor.kt
@@ -32,6 +32,7 @@ import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.Variance
 import com.squareup.kotlinpoet.ksp.writeTo
 import toothpick.compiler.common.generators.TPCodeGenerator
@@ -65,12 +66,14 @@ abstract class ToothpickProcessor(
     }
 
     protected fun KSType.isValidInjectedType(node: KSNode, qualifiedName: String?): Boolean {
-        return if (!isValidInjectedClassKind()) false
+        return if (!isValidInjectedClassKind() && !isTypeAlias()) false
         else !isProviderOrLazy() || isValidProviderOrLazy(node, qualifiedName)
     }
 
     private fun KSType.isValidInjectedClassKind(): Boolean =
         (declaration as? KSClassDeclaration)?.classKind in validInjectableTypes
+
+    private fun KSType.isTypeAlias(): Boolean = declaration is KSTypeAlias
 
     private fun KSType.isValidProviderOrLazy(node: KSNode, qualifiedName: String?): Boolean {
         // e.g. Provider<Foo<String>>

--- a/compiler-core/src/main/java/toothpick/compiler/common/ToothpickProcessor.kt
+++ b/compiler-core/src/main/java/toothpick/compiler/common/ToothpickProcessor.kt
@@ -48,7 +48,7 @@ import javax.inject.Inject
 abstract class ToothpickProcessor(
     processorOptions: Map<String, String>,
     private val codeGenerator: CodeGenerator,
-    protected val logger: KSPLogger
+    protected val logger: KSPLogger,
 ) : SymbolProcessor {
 
     protected val options = processorOptions.readOptions()
@@ -66,9 +66,11 @@ abstract class ToothpickProcessor(
     }
 
     protected fun KSType.isValidInjectedType(node: KSNode, qualifiedName: String?): Boolean {
-        return if (isError) false
-        else if (!isValidInjectedClassKind() && !isTypeAlias()) false
-        else !isProviderOrLazy() || isValidProviderOrLazy(node, qualifiedName)
+        return when {
+            isError -> false
+            !isValidInjectedClassKind() && !isTypeAlias() -> false
+            else -> !isProviderOrLazy() || isValidProviderOrLazy(node, qualifiedName)
+        }
     }
 
     private fun KSType.isValidInjectedClassKind(): Boolean =
@@ -100,7 +102,8 @@ abstract class ToothpickProcessor(
         val firstArgumentArgumentType = firstArgumentArgument.type?.resolve()?.declaration?.qualifiedName?.asString()
 
         val isArgumentStar = firstArgumentArgument.variance == Variance.STAR
-        val isArgumentAny = firstArgumentArgument.variance == Variance.INVARIANT && firstArgumentArgumentType == Any::class.qualifiedName
+        val isArgumentAny =
+            firstArgumentArgument.variance == Variance.INVARIANT && firstArgumentArgumentType == Any::class.qualifiedName
         val areValidArguments = firstArgumentArguments.size <= 1 && (isArgumentStar || isArgumentAny)
 
         if (!areValidArguments) {

--- a/compiler-core/src/main/java/toothpick/compiler/common/generators/targets/VariableInjectionTarget.kt
+++ b/compiler-core/src/main/java/toothpick/compiler/common/generators/targets/VariableInjectionTarget.kt
@@ -22,8 +22,10 @@ package toothpick.compiler.common.generators.targets
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getAnnotationsByType
 import com.google.devtools.ksp.isAnnotationPresent
+import com.google.devtools.ksp.isLocal
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSName
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
@@ -31,6 +33,7 @@ import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.ksp.toClassName
@@ -43,29 +46,31 @@ import javax.inject.Qualifier
  * Information necessary to identify the parameter of a method or a class's property.
  */
 sealed class VariableInjectionTarget(
-    val memberType: KSType,
+    val className: ClassName,
+    val typeName: TypeName,
     val memberName: KSName,
-    val qualifierName: Any?
+    val qualifierName: Any?,
 ) {
     class Instance(
-        memberType: KSType,
+        className: ClassName,
+        typeName: TypeName,
         memberName: KSName,
-        qualifierName: Any?
-    ) : VariableInjectionTarget(memberType, memberName, qualifierName)
+        qualifierName: Any?,
+    ) : VariableInjectionTarget(className, typeName, memberName, qualifierName)
 
     class Lazy(
-        memberType: KSType,
+        className: ClassName,
+        typeName: TypeName,
         memberName: KSName,
         qualifierName: Any?,
-        val kindParamClass: KSType
-    ) : VariableInjectionTarget(memberType, memberName, qualifierName)
+    ) : VariableInjectionTarget(className, typeName, memberName, qualifierName)
 
     class Provider(
-        memberType: KSType,
+        className: ClassName,
+        typeName: TypeName,
         memberName: KSName,
         qualifierName: Any?,
-        val kindParamClass: KSType
-    ) : VariableInjectionTarget(memberType, memberName, qualifierName)
+    ) : VariableInjectionTarget(className, typeName, memberName, qualifierName)
 
     companion object {
 
@@ -85,26 +90,52 @@ sealed class VariableInjectionTarget(
 
         private fun create(name: KSName, type: KSType, qualifierName: String?): VariableInjectionTarget =
             when (type.declaration.qualifiedName?.asString()) {
-                javax.inject.Provider::class.qualifiedName ->
+                javax.inject.Provider::class.qualifiedName -> {
+                    val kindParamClass = type.getInjectedType()
+
                     Provider(
-                        memberType = type,
+                        className = kindParamClass.toClassName(),
+                        typeName = type.toParameterizedTypeName(kindParamClass),
                         memberName = name,
-                        qualifierName = qualifierName,
-                        kindParamClass = type.getInjectedType()
+                        qualifierName = qualifierName
                     )
-                toothpick.Lazy::class.qualifiedName ->
+                }
+                toothpick.Lazy::class.qualifiedName -> {
+                    val kindParamClass = type.getInjectedType()
+
                     Lazy(
-                        memberType = type,
+                        className = kindParamClass.toClassName(),
+                        typeName = type.toParameterizedTypeName(kindParamClass),
                         memberName = name,
-                        qualifierName = qualifierName,
-                        kindParamClass = type.getInjectedType()
+                        qualifierName = qualifierName
                     )
-                else -> Instance(
-                    memberType = type.findActualType(),
+                }
+                else -> createInstanceTarget(name, type, qualifierName)
+            }
+
+        private fun createInstanceTarget(name: KSName, type: KSType, qualifierName: String?): Instance {
+            return if (type.declaration is KSTypeAlias) {
+                val actualTypeClassName = type.findActualType().toClassName()
+                val argumentsTypeNames = type.arguments.map { it.type!!.resolve().toTypeName() }
+
+                Instance(
+                    className = actualTypeClassName,
+                    typeName = type.declaration.toClassName().parameterizedBy(argumentsTypeNames),
+                    memberName = name,
+                    qualifierName = qualifierName
+                )
+            } else {
+                Instance(
+                    className = type.toClassName(),
+                    typeName = type.toTypeName(),
                     memberName = name,
                     qualifierName = qualifierName
                 )
             }
+        }
+
+        private fun KSType.toParameterizedTypeName(kindParamClass: KSType): ParameterizedTypeName =
+            toClassName().parameterizedBy(kindParamClass.toTypeName())
 
         /**
          * Lookup both [javax.inject.Qualifier] and [javax.inject.Named] to provide the name
@@ -155,6 +186,23 @@ sealed class VariableInjectionTarget(
                 this
             }
         }
+
+        /**
+         * Copied from ksp [com.squareup.kotlinpoet.ksp.toClassNameInternal]
+         * With it, we can create a correct type name for typealias (using [parameterizedBy])
+         * Otherwise, we lose the generic parameters
+         */
+        private fun KSDeclaration.toClassName(): ClassName {
+            require(!isLocal()) {
+                "Local/anonymous classes are not supported!"
+            }
+            val pkgName = packageName.asString()
+            val typesString = checkNotNull(qualifiedName).asString().removePrefix("$pkgName.")
+
+            val simpleNames = typesString
+                .split(".")
+            return ClassName(pkgName, simpleNames)
+        }
     }
 }
 
@@ -165,12 +213,6 @@ fun VariableInjectionTarget.getInvokeScopeGetMethodWithNameCodeBlock(): CodeBloc
         is VariableInjectionTarget.Lazy -> "getLazy"
     }
 
-    val className: ClassName = when (this) {
-        is VariableInjectionTarget.Instance -> memberType.toClassName()
-        is VariableInjectionTarget.Provider -> kindParamClass.toClassName()
-        is VariableInjectionTarget.Lazy -> kindParamClass.toClassName()
-    }
-
     return CodeBlock.builder()
         .add("%N(%T::class.java", scopeGetMethodName, className)
         .apply { if (qualifierName != null) add(", %S", qualifierName) }
@@ -178,10 +220,4 @@ fun VariableInjectionTarget.getInvokeScopeGetMethodWithNameCodeBlock(): CodeBloc
         .build()
 }
 
-fun VariableInjectionTarget.getParamType(): TypeName = when (this) {
-    is VariableInjectionTarget.Instance -> memberType.toTypeName()
-    is VariableInjectionTarget.Provider -> memberType.toClassName()
-        .parameterizedBy(kindParamClass.toTypeName())
-    is VariableInjectionTarget.Lazy -> memberType.toClassName()
-        .parameterizedBy(kindParamClass.toTypeName())
-}
+fun VariableInjectionTarget.getParamType(): TypeName = typeName

--- a/compiler-core/src/main/java/toothpick/compiler/common/generators/targets/VariableInjectionTarget.kt
+++ b/compiler-core/src/main/java/toothpick/compiler/common/generators/targets/VariableInjectionTarget.kt
@@ -27,6 +27,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSName
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -99,7 +100,7 @@ sealed class VariableInjectionTarget(
                         kindParamClass = type.getInjectedType()
                     )
                 else -> Instance(
-                    memberType = type,
+                    memberType = type.findActualType(),
                     memberName = name,
                     qualifierName = qualifierName
                 )
@@ -145,6 +146,15 @@ sealed class VariableInjectionTarget(
          * (e.g. in `Lazy<B>`, type is `B`, not `Lazy`).
          */
         private fun KSType.getInjectedType(): KSType = arguments.first().type!!.resolve()
+
+        private fun KSType.findActualType(): KSType {
+            val typeDeclaration = declaration
+            return if (typeDeclaration is KSTypeAlias) {
+                typeDeclaration.type.resolve().findActualType()
+            } else {
+                this
+            }
+        }
     }
 }
 

--- a/compiler-core/src/main/java/toothpick/compiler/common/generators/targets/VariableInjectionTarget.kt
+++ b/compiler-core/src/main/java/toothpick/compiler/common/generators/targets/VariableInjectionTarget.kt
@@ -118,9 +118,15 @@ sealed class VariableInjectionTarget(
                 val actualTypeClassName = type.findActualType().toClassName()
                 val argumentsTypeNames = type.arguments.map { it.type!!.resolve().toTypeName() }
 
+                val typeName = if (argumentsTypeNames.isNotEmpty()) {
+                    type.declaration.toClassName().parameterizedBy(argumentsTypeNames)
+                } else {
+                    type.toTypeName()
+                }
+
                 Instance(
                     className = actualTypeClassName,
-                    typeName = type.declaration.toClassName().parameterizedBy(argumentsTypeNames),
+                    typeName = typeName,
                     memberName = name,
                     qualifierName = qualifierName
                 )

--- a/compiler-factory/src/main/java/toothpick/compiler/factory/FactoryProcessor.kt
+++ b/compiler-factory/src/main/java/toothpick/compiler/factory/FactoryProcessor.kt
@@ -252,12 +252,22 @@ class FactoryProcessor(
 
         if (parentClass.isNonStaticInnerClass()) return false
 
-        return parameters.all { param ->
+        val invalidParams = parameters.filterNot { param ->
             param.type.resolve().isValidInjectedType(
                 node = this,
                 qualifiedName = param.name?.asString()
             )
         }
+
+        if (invalidParams.isNotEmpty()) {
+            logger.error(
+                this,
+                "Class ${parentClass.qualifiedName?.asString()} has invalid parameters: $invalidParams",
+            )
+        }
+
+        return invalidParams.isEmpty()
+
     }
 
     private fun KSFunctionDeclaration.createConstructorInjectionTarget(resolver: Resolver): ConstructorInjectionTarget {

--- a/compiler-factory/src/main/java/toothpick/compiler/factory/FactoryProcessor.kt
+++ b/compiler-factory/src/main/java/toothpick/compiler/factory/FactoryProcessor.kt
@@ -267,7 +267,6 @@ class FactoryProcessor(
         }
 
         return invalidParams.isEmpty()
-
     }
 
     private fun KSFunctionDeclaration.createConstructorInjectionTarget(resolver: Resolver): ConstructorInjectionTarget {

--- a/compiler-factory/src/test/java/toothpick/compiler/factory/FactoryTest.kt
+++ b/compiler-factory/src/test/java/toothpick/compiler/factory/FactoryTest.kt
@@ -2069,8 +2069,8 @@ class FactoryTest {
             """
             package test
             import javax.inject.Inject
-            typealias TestTypeAlias = () -> String
-            class TestNonEmptyConstructor @Inject constructor(testTypeAlias: TestTypeAlias)
+            typealias TestTypeAlias<Entity, Param> = (param: Param) -> Entity
+            class TestNonEmptyConstructor @Inject constructor(testTypeAlias: TestTypeAlias<String, Int>)
             """
         )
 
@@ -2087,7 +2087,8 @@ class FactoryTest {
             package test
             
             import kotlin.Boolean
-            import kotlin.Function0
+            import kotlin.Function1
+            import kotlin.Int
             import kotlin.String
             import kotlin.Suppress
             import toothpick.Factory
@@ -2104,7 +2105,7 @@ class FactoryTest {
               )
               public override fun createInstance(scope: Scope): TestNonEmptyConstructor {
                 val scope = getTargetScope(scope)
-                val param1 = scope.getInstance(Function0::class.java) as Function0<String>
+                val param1 = scope.getInstance(Function1::class.java) as TestTypeAlias<String, Int>
                 return TestNonEmptyConstructor(param1)
               }
             

--- a/compiler-factory/src/test/java/toothpick/compiler/factory/FactoryTest.kt
+++ b/compiler-factory/src/test/java/toothpick/compiler/factory/FactoryTest.kt
@@ -2069,8 +2069,8 @@ class FactoryTest {
             """
             package test
             import javax.inject.Inject
-            typealias TestTypeAlias<Entity, Param> = (param: Param) -> Entity
-            class TestNonEmptyConstructor @Inject constructor(testTypeAlias: TestTypeAlias<String, Int>)
+            typealias TestTypeAlias = String
+            class TestNonEmptyConstructor @Inject constructor(testTypeAlias: TestTypeAlias)
             """
         )
 
@@ -2082,6 +2082,66 @@ class FactoryTest {
     }
 
     private val testNonEmptyConstructorWithTypeAlias_expected = expectedKtSource(
+        "test/TestNonEmptyConstructor__Factory",
+        """
+            package test
+
+            import kotlin.Boolean
+            import kotlin.String
+            import kotlin.Suppress
+            import toothpick.Factory
+            import toothpick.Scope
+            
+            @Suppress(
+              "ClassName",
+              "RedundantVisibilityModifier",
+            )
+            public class TestNonEmptyConstructor__Factory : Factory<TestNonEmptyConstructor> {
+              @Suppress(
+                "UNCHECKED_CAST",
+                "NAME_SHADOWING",
+              )
+              public override fun createInstance(scope: Scope): TestNonEmptyConstructor {
+                val scope = getTargetScope(scope)
+                val param1 = scope.getInstance(String::class.java) as TestTypeAlias
+                return TestNonEmptyConstructor(param1)
+              }
+            
+              public override fun getTargetScope(scope: Scope): Scope = scope
+            
+              public override fun hasScopeAnnotation(): Boolean = false
+            
+              public override fun hasSingletonAnnotation(): Boolean = false
+            
+              public override fun hasReleasableAnnotation(): Boolean = false
+            
+              public override fun hasProvidesSingletonAnnotation(): Boolean = false
+            
+              public override fun hasProvidesReleasableAnnotation(): Boolean = false
+            }
+            """
+    )
+
+    @Test
+    fun testNonEmptyConstructorWithTypeAliasAndGenerics_kt() {
+        val source = ktSource(
+            "TestNonEmptyConstructor",
+            """
+            package test
+            import javax.inject.Inject
+            typealias TestTypeAlias<Entity, Param> = (param: Param) -> Entity
+            class TestNonEmptyConstructor @Inject constructor(testTypeAlias: TestTypeAlias<String, Int>)
+            """
+        )
+
+        compilationAssert()
+            .that(source)
+            .processedWith(FactoryProcessorProvider())
+            .compilesWithoutError()
+            .generatesSources(testNonEmptyConstructorWithTypeAliasAndGenerics_expected)
+    }
+
+    private val testNonEmptyConstructorWithTypeAliasAndGenerics_expected = expectedKtSource(
         "test/TestNonEmptyConstructor__Factory",
         """
             package test

--- a/compiler-factory/src/test/java/toothpick/compiler/factory/FactoryTest.kt
+++ b/compiler-factory/src/test/java/toothpick/compiler/factory/FactoryTest.kt
@@ -2061,4 +2061,85 @@ class FactoryTest {
             }
             """
     )
+
+    @Test
+    fun testNonEmptyConstructorWithTypeAlias_kt() {
+        val source = ktSource(
+            "TestNonEmptyConstructor",
+            """
+            package test
+            import javax.inject.Inject
+            typealias TestTypeAlias = () -> String
+            class TestNonEmptyConstructor @Inject constructor(testTypeAlias: TestTypeAlias)
+            """
+        )
+
+        compilationAssert()
+            .that(source)
+            .processedWith(FactoryProcessorProvider())
+            .compilesWithoutError()
+            .generatesSources(testNonEmptyConstructorWithTypeAlias_expected)
+    }
+
+    private val testNonEmptyConstructorWithTypeAlias_expected = expectedKtSource(
+        "test/TestNonEmptyConstructor__Factory",
+        """
+            package test
+            
+            import kotlin.Boolean
+            import kotlin.Function0
+            import kotlin.String
+            import kotlin.Suppress
+            import toothpick.Factory
+            import toothpick.Scope
+            
+            @Suppress(
+              "ClassName",
+              "RedundantVisibilityModifier",
+            )
+            public class TestNonEmptyConstructor__Factory : Factory<TestNonEmptyConstructor> {
+              @Suppress(
+                "UNCHECKED_CAST",
+                "NAME_SHADOWING",
+              )
+              public override fun createInstance(scope: Scope): TestNonEmptyConstructor {
+                val scope = getTargetScope(scope)
+                val param1 = scope.getInstance(Function0::class.java) as Function0<String>
+                return TestNonEmptyConstructor(param1)
+              }
+            
+              public override fun getTargetScope(scope: Scope): Scope = scope
+            
+              public override fun hasScopeAnnotation(): Boolean = false
+            
+              public override fun hasSingletonAnnotation(): Boolean = false
+            
+              public override fun hasReleasableAnnotation(): Boolean = false
+            
+              public override fun hasProvidesSingletonAnnotation(): Boolean = false
+            
+              public override fun hasProvidesReleasableAnnotation(): Boolean = false
+            }
+            """
+    )
+
+    @Test
+    fun testEmptyConstructorWithIncorrectParameter_kt() {
+        val source = ktSource(
+            "TestNonEmptyConstructor",
+            """
+            package test
+            import javax.inject.Inject
+            class TestNonEmptyConstructor @Inject constructor(invalid: Invalid)
+            """
+        )
+
+        compilationAssert()
+            .that(source)
+            .processedWith(FactoryProcessorProvider())
+            .failsToCompile()
+            .withLogContaining(
+                "Class test.TestNonEmptyConstructor has invalid parameters: [invalid]"
+            )
+    }
 }

--- a/compiler-memberinjector/src/main/java/toothpick/compiler/memberinjector/MemberInjectorProcessor.kt
+++ b/compiler-memberinjector/src/main/java/toothpick/compiler/memberinjector/MemberInjectorProcessor.kt
@@ -169,7 +169,6 @@ class MemberInjectorProcessor(
         }
 
         return isValidProperty
-
     }
 
     private fun KSFunctionDeclaration.isValidInjectAnnotatedMethod(): Boolean {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=fr.outadoc.toothpick-ksp
-VERSION_NAME=1.0.1
+VERSION_NAME=1.0.2
 
 POM_PACKAGING=JAR
 


### PR DESCRIPTION
We use typealiases, so we began to catch an error in runtime after connecting toothpick ksp. The main problems with typealiases - it was necessary to get the correct classname and typename. 
We also added an error output if the parameters are not valid, in order to immediately see which parameter contains the error. Otherwise, it crashes already at runtime due to the lack of a factory.