### PR TITLE
Migrate to ksp 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
 
       - name: Build project

--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk11
+  - openjdk17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import com.diffplug.gradle.spotless.SpotlessExtension
 
 plugins {
     id("org.jetbrains.kotlinx.kover") version "0.8.3"
-    id("com.diffplug.gradle.spotless") version "6.25.0" apply false
+    id("com.diffplug.gradle.spotless") version "6.2.0" apply false
     id("org.jetbrains.kotlin.jvm") version "2.0.0" apply false
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
 
 plugins {
-    id("org.jetbrains.kotlinx.kover") version "0.5.0"
-    id("com.diffplug.gradle.spotless") version "6.2.0" apply false
-    id("org.jetbrains.kotlin.jvm") version "1.7.22" apply false
+    id("org.jetbrains.kotlinx.kover") version "0.8.3"
+    id("com.diffplug.gradle.spotless") version "6.25.0" apply false
+    id("org.jetbrains.kotlin.jvm") version "2.0.0" apply false
 }
 
 subprojects {

--- a/compiler-core/build.gradle.kts
+++ b/compiler-core/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -6,8 +7,8 @@ plugins {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "1.8"
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/compiler-factory/build.gradle.kts
+++ b/compiler-factory/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -6,8 +7,8 @@ plugins {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "1.8"
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/compiler-factory/src/main/java/toothpick/compiler/factory/generators/FactoryGenerator.kt
+++ b/compiler-factory/src/main/java/toothpick/compiler/factory/generators/FactoryGenerator.kt
@@ -144,7 +144,7 @@ internal class FactoryGenerator(
         }
 
         FunSpec.builder("createInstance")
-            .addModifiers(KModifier.OVERRIDE)
+            .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
             .addParameter("scope", Scope::class)
             .returns(sourceClassName)
             .apply {
@@ -210,7 +210,7 @@ internal class FactoryGenerator(
     private fun TypeSpec.Builder.emitGetTargetScope(): TypeSpec.Builder = apply {
         val scopeName = constructorInjectionTarget.scopeName
         FunSpec.builder("getTargetScope")
-            .addModifiers(KModifier.OVERRIDE)
+            .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
             .addParameter("scope", Scope::class)
             .returns(Scope::class)
             .addStatement(
@@ -236,7 +236,7 @@ internal class FactoryGenerator(
         val scopeName = constructorInjectionTarget.scopeName
         val hasScopeAnnotation = scopeName != null
         FunSpec.builder("hasScopeAnnotation")
-            .addModifiers(KModifier.OVERRIDE)
+            .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
             .returns(Boolean::class)
             .addStatement("return %L", hasScopeAnnotation)
             .build()
@@ -245,7 +245,7 @@ internal class FactoryGenerator(
 
     private fun TypeSpec.Builder.emitHasSingletonAnnotation(): TypeSpec.Builder = apply {
         FunSpec.builder("hasSingletonAnnotation")
-            .addModifiers(KModifier.OVERRIDE)
+            .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
             .returns(Boolean::class)
             .addStatement(
                 "return %L",
@@ -257,7 +257,7 @@ internal class FactoryGenerator(
 
     private fun TypeSpec.Builder.emitHasReleasableAnnotation(): TypeSpec.Builder = apply {
         FunSpec.builder("hasReleasableAnnotation")
-            .addModifiers(KModifier.OVERRIDE)
+            .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
             .returns(Boolean::class)
             .addStatement(
                 "return %L",
@@ -269,7 +269,7 @@ internal class FactoryGenerator(
 
     private fun TypeSpec.Builder.emitHasProvidesSingletonAnnotation(): TypeSpec.Builder = apply {
         FunSpec.builder("hasProvidesSingletonAnnotation")
-            .addModifiers(KModifier.OVERRIDE)
+            .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
             .returns(Boolean::class)
             .addStatement(
                 "return %L",
@@ -281,7 +281,7 @@ internal class FactoryGenerator(
 
     private fun TypeSpec.Builder.emitHasProvidesReleasableAnnotation(): TypeSpec.Builder = apply {
         FunSpec.builder("hasProvidesReleasableAnnotation")
-            .addModifiers(KModifier.OVERRIDE)
+            .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
             .returns(Boolean::class)
             .addStatement(
                 "return %L",

--- a/compiler-memberinjector/build.gradle.kts
+++ b/compiler-memberinjector/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -6,8 +7,8 @@ plugins {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "1.8"
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/compiler-memberinjector/src/main/java/toothpick/compiler/memberinjector/generators/MemberInjectorGenerator.kt
+++ b/compiler-memberinjector/src/main/java/toothpick/compiler/memberinjector/generators/MemberInjectorGenerator.kt
@@ -110,7 +110,7 @@ internal class MemberInjectorGenerator(
     ): TypeSpec.Builder = apply {
         addFunction(
             FunSpec.builder("inject")
-                .addModifiers(KModifier.OVERRIDE)
+                .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
                 .addParameter("target", sourceClassName)
                 .addParameter("scope", Scope::class)
                 .apply {

--- a/compiler-memberinjector/src/test/java/toothpick/compiler/memberinjector/FieldMemberInjectorTest.kt
+++ b/compiler-memberinjector/src/test/java/toothpick/compiler/memberinjector/FieldMemberInjectorTest.kt
@@ -82,7 +82,6 @@ class FieldMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -92,7 +91,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.foo = scope.getInstance(Foo::class.java) as Foo
               }
             }
@@ -150,7 +149,6 @@ class FieldMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -160,7 +158,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.foo = scope.getInstance(Foo::class.java, "bar") as Foo
               }
             }
@@ -224,7 +222,6 @@ class FieldMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -234,7 +231,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.foo = scope.getInstance(Foo::class.java, "test.Bar") as Foo
               }
             }
@@ -294,7 +291,6 @@ class FieldMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -304,7 +300,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.foo = scope.getInstance(Foo::class.java) as Foo
               }
             }
@@ -371,7 +367,6 @@ class FieldMemberInjectorTest {
             
             import javax.inject.Provider
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -381,7 +376,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.foo = scope.getProvider(Foo::class.java, "test.Bar") as Provider<Foo>
               }
             }
@@ -444,7 +439,6 @@ class FieldMemberInjectorTest {
             
             import javax.inject.Provider
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -454,7 +448,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.foo = scope.getProvider(Foo::class.java) as Provider<Foo>
               }
             }
@@ -521,7 +515,6 @@ class FieldMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -531,7 +524,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.foo = scope.getInstance(Foo::class.java, "test.Bar") as Foo
               }
             }
@@ -649,7 +642,6 @@ class FieldMemberInjectorTest {
             
             import javax.inject.Provider
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -659,7 +651,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.foo = scope.getProvider(Foo::class.java) as Provider<Foo>
               }
             }
@@ -717,7 +709,6 @@ class FieldMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.Lazy
             import toothpick.MemberInjector
             import toothpick.Scope
@@ -728,7 +719,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.foo = scope.getLazy(Foo::class.java) as Lazy<Foo>
               }
             }
@@ -759,7 +750,6 @@ class FieldMemberInjectorTest {
             
             import kotlin.Any
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.Lazy
             import toothpick.MemberInjector
             import toothpick.Scope
@@ -770,7 +760,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.foo = scope.getLazy(Foo::class.java) as Lazy<Foo<Any>>
               }
             }
@@ -805,7 +795,6 @@ class FieldMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.Lazy
             import toothpick.MemberInjector
             import toothpick.Scope
@@ -816,7 +805,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.foo = scope.getLazy(Foo::class.java) as Lazy<Foo<*>>
               }
             }
@@ -880,7 +869,6 @@ class FieldMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -890,7 +878,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.foo = scope.getInstance(Foo::class.java) as Foo
                 target.foo2 = scope.getInstance(Foo::class.java) as Foo
               }
@@ -1300,7 +1288,6 @@ class FieldMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -1314,7 +1301,7 @@ class FieldMemberInjectorTest {
               private val superMemberInjector: MemberInjector<TestMemberInjection.InnerSuperClass> =
                   `TestMemberInjection${'$'}InnerSuperClass__MemberInjector`()
             
-              public override fun inject(target: TestMemberInjection.InnerClass, scope: Scope): Unit {
+              public override fun inject(target: TestMemberInjection.InnerClass, scope: Scope) {
                 superMemberInjector.inject(target, scope)
                 target.foo = scope.getInstance(Foo::class.java) as Foo
               }
@@ -1381,7 +1368,6 @@ class FieldMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -1394,7 +1380,7 @@ class FieldMemberInjectorTest {
               private val superMemberInjector: MemberInjector<TestMemberInjectionParent> =
                   TestMemberInjectionParent__MemberInjector()
             
-              public override fun inject(target: TestMemberInjection, scope: Scope): Unit {
+              public override fun inject(target: TestMemberInjection, scope: Scope) {
                 superMemberInjector.inject(target, scope)
                 target.foo = scope.getInstance(Foo::class.java) as Foo
               }
@@ -1461,7 +1447,6 @@ class FieldMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -1474,7 +1459,7 @@ class FieldMemberInjectorTest {
               private val superMemberInjector: MemberInjector<TestMemberInjectionParent<*>> =
                   TestMemberInjectionParent__MemberInjector()
             
-              public override fun inject(target: TestMemberInjection, scope: Scope): Unit {
+              public override fun inject(target: TestMemberInjection, scope: Scope) {
                 superMemberInjector.inject(target, scope)
                 target.foo = scope.getInstance(Foo::class.java) as Foo
               }
@@ -1535,7 +1520,6 @@ class FieldMemberInjectorTest {
             
             import kotlin.String
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -1545,7 +1529,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.testTypeAlias = scope.getInstance(String::class.java) as TestTypeAlias
               }
             }
@@ -1583,7 +1567,6 @@ class FieldMemberInjectorTest {
             import kotlin.Int
             import kotlin.String
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -1593,7 +1576,7 @@ class FieldMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestFieldInjection__MemberInjector : MemberInjector<TestFieldInjection> {
-              public override fun inject(target: TestFieldInjection, scope: Scope): Unit {
+              public override fun inject(target: TestFieldInjection, scope: Scope) {
                 target.testTypeAlias = scope.getInstance(Function1::class.java) as TestTypeAlias<String, Int>
               }
             }

--- a/compiler-memberinjector/src/test/java/toothpick/compiler/memberinjector/MethodMemberInjectorTest.kt
+++ b/compiler-memberinjector/src/test/java/toothpick/compiler/memberinjector/MethodMemberInjectorTest.kt
@@ -82,7 +82,6 @@ class MethodMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -92,7 +91,7 @@ class MethodMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestMethodInjection__MemberInjector : MemberInjector<TestMethodInjection> {
-              public override fun inject(target: TestMethodInjection, scope: Scope): Unit {
+              public override fun inject(target: TestMethodInjection, scope: Scope) {
                 val param1 = scope.getInstance(Foo::class.java) as Foo
                 target.m(param1)
               }
@@ -152,7 +151,6 @@ class MethodMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.Lazy
             import toothpick.MemberInjector
             import toothpick.Scope
@@ -163,7 +161,7 @@ class MethodMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestMethodInjection__MemberInjector : MemberInjector<TestMethodInjection> {
-              public override fun inject(target: TestMethodInjection, scope: Scope): Unit {
+              public override fun inject(target: TestMethodInjection, scope: Scope) {
                 val param1 = scope.getLazy(Foo::class.java) as Lazy<Foo>
                 target.m(param1)
               }
@@ -224,7 +222,6 @@ class MethodMemberInjectorTest {
             
             import javax.inject.Provider
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -234,7 +231,7 @@ class MethodMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestMethodInjection__MemberInjector : MemberInjector<TestMethodInjection> {
-              public override fun inject(target: TestMethodInjection, scope: Scope): Unit {
+              public override fun inject(target: TestMethodInjection, scope: Scope) {
                 val param1 = scope.getProvider(Foo::class.java) as Provider<Foo>
                 target.m(param1)
               }
@@ -266,7 +263,6 @@ class MethodMemberInjectorTest {
             
             import kotlin.Any
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.Lazy
             import toothpick.MemberInjector
             import toothpick.Scope
@@ -277,7 +273,7 @@ class MethodMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestMethodInjection__MemberInjector : MemberInjector<TestMethodInjection> {
-              public override fun inject(target: TestMethodInjection, scope: Scope): Unit {
+              public override fun inject(target: TestMethodInjection, scope: Scope) {
                 val param1 = scope.getLazy(Foo::class.java) as Lazy<Foo<Any>>
                 target.m(param1)
               }
@@ -314,7 +310,6 @@ class MethodMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.Lazy
             import toothpick.MemberInjector
             import toothpick.Scope
@@ -325,7 +320,7 @@ class MethodMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestMethodInjection__MemberInjector : MemberInjector<TestMethodInjection> {
-              public override fun inject(target: TestMethodInjection, scope: Scope): Unit {
+              public override fun inject(target: TestMethodInjection, scope: Scope) {
                 val param1 = scope.getLazy(Foo::class.java) as Lazy<Foo<*>>
                 target.m(param1)
               }
@@ -651,7 +646,6 @@ class MethodMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -665,8 +659,7 @@ class MethodMemberInjectorTest {
               private val superMemberInjector: MemberInjector<TestMethodInjectionParent> =
                   TestMethodInjectionParent__MemberInjector()
             
-              public override fun inject(target: TestMethodInjectionParent.TestMethodInjection, scope: Scope):
-                  Unit {
+              public override fun inject(target: TestMethodInjectionParent.TestMethodInjection, scope: Scope) {
                 superMemberInjector.inject(target, scope)
               }
             }
@@ -725,7 +718,6 @@ class MethodMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -735,7 +727,7 @@ class MethodMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestMethodInjection__MemberInjector : MemberInjector<TestMethodInjection> {
-              public override fun inject(target: TestMethodInjection, scope: Scope): Unit {
+              public override fun inject(target: TestMethodInjection, scope: Scope) {
                 val param1 = scope.getInstance(Foo::class.java) as Foo
                 target.m(param1)
               }
@@ -795,7 +787,6 @@ class MethodMemberInjectorTest {
             package test
             
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -805,7 +796,7 @@ class MethodMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestMethodInjection__MemberInjector : MemberInjector<TestMethodInjection> {
-              public override fun inject(target: TestMethodInjection, scope: Scope): Unit {
+              public override fun inject(target: TestMethodInjection, scope: Scope) {
                 val param1 = scope.getInstance(Foo::class.java) as Foo
                 target.m(param1)
               }
@@ -842,7 +833,6 @@ class MethodMemberInjectorTest {
             
             import kotlin.String
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -852,7 +842,7 @@ class MethodMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestMethodInjection__MemberInjector : MemberInjector<TestMethodInjection> {
-              public override fun inject(target: TestMethodInjection, scope: Scope): Unit {
+              public override fun inject(target: TestMethodInjection, scope: Scope) {
                 val param1 = scope.getInstance(String::class.java) as TestTypeAlias
                 target.m(param1)
               }
@@ -891,7 +881,6 @@ class MethodMemberInjectorTest {
             import kotlin.Int
             import kotlin.String
             import kotlin.Suppress
-            import kotlin.Unit
             import toothpick.MemberInjector
             import toothpick.Scope
             
@@ -901,7 +890,7 @@ class MethodMemberInjectorTest {
               "UNCHECKED_CAST",
             )
             public class TestMethodInjection__MemberInjector : MemberInjector<TestMethodInjection> {
-              public override fun inject(target: TestMethodInjection, scope: Scope): Unit {
+              public override fun inject(target: TestMethodInjection, scope: Scope) {
                 val param1 = scope.getInstance(Function1::class.java) as TestTypeAlias<String, Int>
                 target.m(param1)
               }

--- a/compiler-test/build.gradle.kts
+++ b/compiler-test/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -5,8 +6,8 @@ plugins {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "1.8"
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/compiler-test/src/main/java/toothpick/compiler/AssertionUtils.kt
+++ b/compiler-test/src/main/java/toothpick/compiler/AssertionUtils.kt
@@ -15,6 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(ExperimentalCompilerApi::class, ExperimentalCompilerApi::class)
+
 package toothpick.compiler
 
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -23,6 +25,7 @@ import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.kspArgs
 import com.tschuchort.compiletesting.kspSourcesDir
 import com.tschuchort.compiletesting.symbolProcessorProviders
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -6,8 +7,8 @@ plugins {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "1.8"
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,5 @@ POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=outadoc
 POM_DEVELOPER_NAME=Baptiste Candellier
+
+ksp.useKSP2=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=fr.outadoc.toothpick-ksp
-VERSION_NAME=1.0.2
+VERSION_NAME=1.1.0
 
 POM_PACKAGING=JAR
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
-kotlinpoet = "1.12.0"
-compiletesting = "1.4.9"
+kotlinpoet = "1.18.1"
+compiletesting = "1.6.0"
 
 [libraries]
 compiletesting-kt = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "compiletesting" }
 compiletesting-ksp = { module = "com.github.tschuchortdev:kotlin-compile-testing-ksp", version.ref = "compiletesting" }
 inject = "javax.inject:javax.inject:1"
-junit4 = "junit:junit:4.13-beta-3"
+junit4 = "junit:junit:4.13.2"
 kotlinpoet-core = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinpoet" }
-ksp = "com.google.devtools.ksp:symbol-processing-api:1.7.22-1.0.8"
+ksp = "com.google.devtools.ksp:symbol-processing-api:2.0.0-1.0.23"
 tp = "com.github.stephanenicolas.toothpick:toothpick:3.1.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Jul 23 11:46:34 AMT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Dependency versions were updated and migration to KSP2 was performed.

kotlinpoet now includes code like this

```
// FunSpec.kt

if (returnType != UNIT || emitUnitReturnType()) {
  codeWriter.emitCode(": %T", returnType)
}

/**
 * Returns whether [Unit] should be emitted as the return type.
 *
 * [Unit] is emitted as return type on a function only if it is an expression body.
 */
private fun emitUnitReturnType(): Boolean {
  if (isConstructor) {
    return false
  }
  if (name == GETTER || name == SETTER) {
    // Getter/setters don't emit return types
    return false
  }

  return body.asExpressionBody() != null
}
```

accordingly, I had to remove the explicit Unit type as function return type.