### PR TITLE
chore: upgrade kotlin to 2.0.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,10 +9,10 @@ inject = "javax.inject:javax.inject:1"
 junit4 = "junit:junit:4.13.2"
 kotlinpoet-core = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinpoet" }
-ksp = "com.google.devtools.ksp:symbol-processing-api:2.0.0-1.0.23"
+ksp = "com.google.devtools.ksp:symbol-processing-api:2.0.10-1.0.24"
 tp = "com.github.stephanenicolas.toothpick:toothpick:3.1.0"
 
 [plugins]
-kotlin = { id = "org.jetbrains.kotlin.jvm", version = "2.0.0" }
+kotlin = { id = "org.jetbrains.kotlin.jvm", version = "2.0.10" }
 kover = { id = "org.jetbrains.kotlinx.kover", version = "0.8.3" }
 spotless = { id = "com.diffplug.gradle.spotless", version = "6.2.0" }


### PR DESCRIPTION
This PR upgrades Kotlin and KSP to 2.0.10.