### PR TITLE
Implement generic support for all generic types that have zero or one constraint

### DIFF
--- a/compiler-core/src/main/java/toothpick/compiler/common/ToothpickProcessor.kt
+++ b/compiler-core/src/main/java/toothpick/compiler/common/ToothpickProcessor.kt
@@ -199,7 +199,13 @@ abstract class ToothpickProcessor(
         val javaAnnotations =
             getAnnotationsByType<SuppressWarnings>()
                 .flatMap { annotation ->
-                    annotation.arguments.map { arg -> arg.value as String }
+                    annotation.arguments.flatMap { arg ->
+                        when (val value = arg.value) {
+                            is String -> listOf(value)
+                            is Iterable<*> -> value.filterIsInstance<String>()
+                            else -> emptyList()
+                        }
+                    }
                 }
 
         return (kotlinAnnotations + javaAnnotations)

--- a/compiler-core/src/main/java/toothpick/compiler/common/generators/GenericsHelper.kt
+++ b/compiler-core/src/main/java/toothpick/compiler/common/generators/GenericsHelper.kt
@@ -1,0 +1,50 @@
+package toothpick.compiler.common.generators
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.STAR
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
+import toothpick.compiler.common.generators.GenericSupportException.Companion.TOO_MANY_CONSTRAINTS
+
+object GenericsHelper {
+    /**
+     * Resolves class declaration to a parameterized (generic) TypeName. Tries to infer
+     * a concrete type for the generic based on the first and only constraint.
+     * E.g. "MyClass<T> where T: Exception" will resolve to MyClass<Exception>"
+     * If it does not have a constraint it will resolve to STAR, e.g.
+     * "MyClass<T>*" will resolve to "MyClass<*>"
+     * Does not support multiple constraints
+     */
+    fun resolveGenericTypeToConstraint(clazz: KSClassDeclaration): TypeName {
+        val clazzName = clazz.toClassName()
+        if (clazz.typeParameters.isEmpty()) return clazzName
+        val genericTypeNames: List<TypeName> = clazz.typeParameters.map { type ->
+            val bounds = type.bounds.toList()
+            if (bounds.isEmpty()) {
+                STAR
+            } else {
+                resolveTypeToFirstTypeBoundary(type)
+            }
+        }
+
+        val typedSourceClass: TypeName = clazzName.parameterizedBy(genericTypeNames)
+        return typedSourceClass
+    }
+
+    private fun resolveTypeToFirstTypeBoundary(typeParam: KSTypeParameter): TypeName {
+        if (typeParam.bounds.count() > 1) throw GenericSupportException(TOO_MANY_CONSTRAINTS)
+        val firstConstraint = typeParam.bounds.firstOrNull()
+        return firstConstraint?.toTypeName() ?: STAR
+    }
+}
+
+class GenericSupportException(message: String, cause: Exception? = null) : RuntimeException(message, cause) {
+    companion object {
+        const val TOO_MANY_CONSTRAINTS =
+            "Generic classes with 2 or more constraints is not supported at this time. Rewrite your class to have 1 or 0 constraints " +
+                    "for Toothpick injection support with KSP"
+    }
+}

--- a/compiler-core/src/main/java/toothpick/compiler/common/generators/TypeExtensions.kt
+++ b/compiler-core/src/main/java/toothpick/compiler/common/generators/TypeExtensions.kt
@@ -19,7 +19,12 @@ package toothpick.compiler.common.generators
 
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.STAR
+import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.ksp.toClassName
 
 /**
  * Alternative to [com.google.devtools.ksp.getAnnotationsByType] that retrieves [KSAnnotation]s instead.
@@ -29,5 +34,19 @@ inline fun <reified T : Annotation> KSAnnotated.getAnnotationsByType(): Sequence
         val className = T::class.asClassName()
         annotation.shortName.asString() == className.simpleName &&
             annotation.annotationType.resolve().declaration.qualifiedName?.asString() == className.canonicalName
+    }
+}
+
+/**
+ * Resolves to star-parameterized TypeName if this is a generic.
+ * A plain non-generic class will resolve to its basic class name
+ * A generic class, e.g. "MyClass<Exception>" will result in a TypeName "MyClass<*>"
+ */
+fun KSClassDeclaration.maybeStarParameterizedClassName(): TypeName {
+    return if (this.typeParameters.isEmpty()) {
+        toClassName()
+    } else {
+        val starList = List(typeParameters.size) { STAR }
+        toClassName().parameterizedBy(starList)
     }
 }

--- a/compiler-factory/src/test/java/toothpick/compiler/factory/FactoryGenericSupportTest.kt
+++ b/compiler-factory/src/test/java/toothpick/compiler/factory/FactoryGenericSupportTest.kt
@@ -1,0 +1,439 @@
+package toothpick.compiler.factory
+
+import org.junit.Test
+import toothpick.compiler.common.generators.GenericSupportException
+import toothpick.compiler.compilationAssert
+import toothpick.compiler.compilesWithoutError
+import toothpick.compiler.expectedKtSource
+import toothpick.compiler.failsToCompile
+import toothpick.compiler.generatesSources
+import toothpick.compiler.ktSource
+import toothpick.compiler.processedWith
+import toothpick.compiler.that
+import toothpick.compiler.withLogContaining
+
+class FactoryGenericSupportTest {
+    @Test
+    fun typed_class_inheriting_generic_class() {
+        val source = ktSource(
+            "TestGeneric1",
+            """
+            package test
+            import toothpick.InjectConstructor
+            
+            class GenericBaseClass<T> 
+            
+            @InjectConstructor
+            class TestGeneric1 : GenericBaseClass<String>
+            """
+        )
+
+        val expectedResult = expectedKtSource(
+            "test/TestGeneric1__Factory",
+            """
+            package test
+            
+            import kotlin.Boolean
+            import kotlin.Suppress
+            import toothpick.Factory
+            import toothpick.Scope
+
+            @Suppress(
+              "ClassName",
+              "RedundantVisibilityModifier",
+            )
+            public class TestGeneric1__Factory : Factory<TestGeneric1> {
+              public override fun createInstance(scope: Scope): TestGeneric1 = TestGeneric1()
+            
+              public override fun getTargetScope(scope: Scope): Scope = scope
+            
+              public override fun hasScopeAnnotation(): Boolean = false
+            
+              public override fun hasSingletonAnnotation(): Boolean = false
+            
+              public override fun hasReleasableAnnotation(): Boolean = false
+            
+              public override fun hasProvidesSingletonAnnotation(): Boolean = false
+            
+              public override fun hasProvidesReleasableAnnotation(): Boolean = false
+            }
+            """
+        )
+
+        compilationAssert()
+            .that(source)
+            .processedWith(FactoryProcessorProvider())
+            .compilesWithoutError()
+            .generatesSources(expectedResult)
+    }
+
+    @Test
+    fun generic_class_inheriting_generic_class() {
+        val source = ktSource(
+            "TestGeneric2",
+            """
+            package test
+            import toothpick.InjectConstructor
+            
+            class GenericBaseClass<T> 
+            
+            @InjectConstructor
+            class TestGeneric2<T> : GenericBaseClass<T>
+            """
+        )
+
+        val expectedResult = expectedKtSource(
+            "test/TestGeneric2__Factory",
+            """
+            package test
+            
+            import kotlin.Any
+            import kotlin.Boolean
+            import kotlin.Suppress
+            import toothpick.Factory
+            import toothpick.Scope
+
+            @Suppress(
+              "ClassName",
+              "RedundantVisibilityModifier",
+            )
+            public class TestGeneric2__Factory : Factory<TestGeneric2<*>> {
+              public override fun createInstance(scope: Scope): TestGeneric2<Any?> = TestGeneric2<Any?>()
+            
+              public override fun getTargetScope(scope: Scope): Scope = scope
+            
+              public override fun hasScopeAnnotation(): Boolean = false
+            
+              public override fun hasSingletonAnnotation(): Boolean = false
+            
+              public override fun hasReleasableAnnotation(): Boolean = false
+            
+              public override fun hasProvidesSingletonAnnotation(): Boolean = false
+            
+              public override fun hasProvidesReleasableAnnotation(): Boolean = false
+            }
+            """
+        )
+
+        compilationAssert()
+            .that(source)
+            .processedWith(FactoryProcessorProvider())
+            .compilesWithoutError()
+            .generatesSources(expectedResult)
+    }
+
+    @Test
+    fun generic_class_two_type_params_two_bounds() {
+        val source = ktSource(
+            "TestGeneric6",
+            """
+            package test
+            import java.lang.Exception
+            import toothpick.InjectConstructor
+            
+            
+            @InjectConstructor
+            class TestGeneric6<T, Q> where T : Exception, Q: Any
+            """
+        )
+
+        val expectedResult =
+            expectedKtSource(
+                "test/TestGeneric6__Factory",
+                """
+            package test
+            
+            import java.lang.Exception
+            import kotlin.Any
+            import kotlin.Boolean
+            import kotlin.Suppress
+            import toothpick.Factory
+            import toothpick.Scope
+
+            @Suppress(
+              "ClassName",
+              "RedundantVisibilityModifier",
+            )
+            public class TestGeneric6__Factory : Factory<TestGeneric6<*, *>> {
+              public override fun createInstance(scope: Scope): TestGeneric6<Exception, Any> =
+                  TestGeneric6<Exception, Any>()
+            
+              public override fun getTargetScope(scope: Scope): Scope = scope
+            
+              public override fun hasScopeAnnotation(): Boolean = false
+            
+              public override fun hasSingletonAnnotation(): Boolean = false
+            
+              public override fun hasReleasableAnnotation(): Boolean = false
+            
+              public override fun hasProvidesSingletonAnnotation(): Boolean = false
+            
+              public override fun hasProvidesReleasableAnnotation(): Boolean = false
+            }
+            """
+            )
+
+        compilationAssert()
+            .that(source)
+            .processedWith(FactoryProcessorProvider())
+            .compilesWithoutError()
+            .generatesSources(expectedResult)
+    }
+
+    @Test
+    fun generic_class_two_type_params_inheriting_one() {
+        val source = ktSource(
+            "TestGeneric3",
+            """
+            package test
+            import toothpick.InjectConstructor
+            
+            class GenericBaseClass<T> 
+            
+            @InjectConstructor
+            class TestGeneric3<T, U> : GenericBaseClass<T>
+            """
+        )
+
+        val expectedResult = expectedKtSource(
+            "test/TestGeneric3__Factory",
+            """
+            package test
+            
+            import kotlin.Any
+            import kotlin.Boolean
+            import kotlin.Suppress
+            import toothpick.Factory
+            import toothpick.Scope
+
+            @Suppress(
+              "ClassName",
+              "RedundantVisibilityModifier",
+            )
+            public class TestGeneric3__Factory : Factory<TestGeneric3<*, *>> {
+              public override fun createInstance(scope: Scope): TestGeneric3<Any?, Any?> =
+                  TestGeneric3<Any?, Any?>()
+            
+              public override fun getTargetScope(scope: Scope): Scope = scope
+            
+              public override fun hasScopeAnnotation(): Boolean = false
+            
+              public override fun hasSingletonAnnotation(): Boolean = false
+            
+              public override fun hasReleasableAnnotation(): Boolean = false
+            
+              public override fun hasProvidesSingletonAnnotation(): Boolean = false
+            
+              public override fun hasProvidesReleasableAnnotation(): Boolean = false
+            }
+            """
+        )
+
+        compilationAssert()
+            .that(source)
+            .processedWith(FactoryProcessorProvider())
+            .compilesWithoutError()
+            .generatesSources(expectedResult)
+    }
+
+    @Test
+    fun generic_class_with_bounds_to_generic_class() {
+        val source = ktSource(
+            "TestGeneric4",
+            """
+            package test
+            import toothpick.InjectConstructor
+            
+            class GenericClass<T> 
+            
+            @InjectConstructor
+            class TestGeneric4<T> where T : GenericClass<*>
+            """
+        )
+
+        val expectedResult = expectedKtSource(
+            "test/TestGeneric4__Factory",
+            """
+            package test
+            
+            import kotlin.Boolean
+            import kotlin.Suppress
+            import toothpick.Factory
+            import toothpick.Scope
+
+            @Suppress(
+              "ClassName",
+              "RedundantVisibilityModifier",
+            )
+            public class TestGeneric4__Factory : Factory<TestGeneric4<*>> {
+              public override fun createInstance(scope: Scope): TestGeneric4<GenericClass<*>> =
+                  TestGeneric4<GenericClass<*>>()
+            
+              public override fun getTargetScope(scope: Scope): Scope = scope
+            
+              public override fun hasScopeAnnotation(): Boolean = false
+            
+              public override fun hasSingletonAnnotation(): Boolean = false
+            
+              public override fun hasReleasableAnnotation(): Boolean = false
+            
+              public override fun hasProvidesSingletonAnnotation(): Boolean = false
+            
+              public override fun hasProvidesReleasableAnnotation(): Boolean = false
+            }
+            """
+        )
+
+        compilationAssert()
+            .that(source)
+            .processedWith(FactoryProcessorProvider())
+            .compilesWithoutError()
+            .generatesSources(expectedResult)
+    }
+
+    @Test
+    fun generic_class_with_bounds_to_trivial_class() {
+        val source = ktSource(
+            "TestGeneric5",
+            """
+            package test
+            import java.lang.Exception
+            import toothpick.InjectConstructor
+            
+            
+            @InjectConstructor
+            class TestGeneric5<T> where T : Exception
+            """
+        )
+
+        val exptectedResult = expectedKtSource(
+            "test/TestGeneric5__Factory",
+            """
+            package test
+            
+            import java.lang.Exception
+            import kotlin.Boolean
+            import kotlin.Suppress
+            import toothpick.Factory
+            import toothpick.Scope
+
+            @Suppress(
+              "ClassName",
+              "RedundantVisibilityModifier",
+            )
+            public class TestGeneric5__Factory : Factory<TestGeneric5<*>> {
+              public override fun createInstance(scope: Scope): TestGeneric5<Exception> =
+                  TestGeneric5<Exception>()
+            
+              public override fun getTargetScope(scope: Scope): Scope = scope
+            
+              public override fun hasScopeAnnotation(): Boolean = false
+            
+              public override fun hasSingletonAnnotation(): Boolean = false
+            
+              public override fun hasReleasableAnnotation(): Boolean = false
+            
+              public override fun hasProvidesSingletonAnnotation(): Boolean = false
+            
+              public override fun hasProvidesReleasableAnnotation(): Boolean = false
+            }
+            """
+        )
+
+        compilationAssert()
+            .that(source)
+            .processedWith(FactoryProcessorProvider())
+            .compilesWithoutError()
+            .generatesSources(exptectedResult)
+    }
+
+    @Test
+    fun member_injection_generic_class() {
+        val source = ktSource(
+            "TestGenericMemberInjection",
+            """
+            package test
+            import javax.inject.Inject
+            import toothpick.InjectConstructor
+            
+            
+            class TestGenericMemberInjection<T> where T: Any {
+                 @Inject
+                 lateinit var myVar: String
+            }
+            """
+        )
+
+        val expectedResult =
+            expectedKtSource(
+                "test/TestGenericMemberInjection__Factory",
+                """
+            package test
+
+            import kotlin.Any
+            import kotlin.Boolean
+            import kotlin.Suppress
+            import toothpick.Factory
+            import toothpick.MemberInjector
+            import toothpick.Scope
+
+            @Suppress(
+              "ClassName",
+              "RedundantVisibilityModifier",
+            )
+            public class TestGenericMemberInjection__Factory : Factory<TestGenericMemberInjection<*>> {
+              private val memberInjector: MemberInjector<TestGenericMemberInjection<*>> =
+                  TestGenericMemberInjection__MemberInjector()
+
+              @Suppress("NAME_SHADOWING")
+              public override fun createInstance(scope: Scope): TestGenericMemberInjection<Any> {
+                val scope = getTargetScope(scope)
+                return TestGenericMemberInjection<Any>()
+                .apply {
+                  memberInjector.inject(this, scope)
+                }
+              }
+            
+              public override fun getTargetScope(scope: Scope): Scope = scope
+            
+              public override fun hasScopeAnnotation(): Boolean = false
+            
+              public override fun hasSingletonAnnotation(): Boolean = false
+            
+              public override fun hasReleasableAnnotation(): Boolean = false
+            
+              public override fun hasProvidesSingletonAnnotation(): Boolean = false
+            
+              public override fun hasProvidesReleasableAnnotation(): Boolean = false
+            }
+            """
+            )
+
+        compilationAssert()
+            .that(source)
+            .processedWith(FactoryProcessorProvider())
+            .compilesWithoutError()
+            .generatesSources(expectedResult)
+    }
+
+    @Test
+    fun `generic class with two constraints shall throw exception`() {
+        val source = ktSource(
+            name = "test/GenericClassTwoConstraints__Factory",
+            contents = """
+                package test
+
+                import toothpick.InjectConstructor
+
+                @InjectConstructor
+                class GenericClassTwoConstraints<T>(val text: String) where T: java.lang.Exception, T: java.lang.ConstantGroup
+            """
+        )
+
+        compilationAssert()
+            .that(source)
+            .processedWith(FactoryProcessorProvider())
+            .failsToCompile()
+            .withLogContaining(GenericSupportException.TOO_MANY_CONSTRAINTS)
+    }
+}

--- a/compiler-memberinjector/src/main/java/toothpick/compiler/memberinjector/generators/MemberInjectorGenerator.kt
+++ b/compiler-memberinjector/src/main/java/toothpick/compiler/memberinjector/generators/MemberInjectorGenerator.kt
@@ -19,17 +19,8 @@ package toothpick.compiler.memberinjector.generators
 
 import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.squareup.kotlinpoet.AnnotationSpec
-import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.FileSpec
-import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import com.squareup.kotlinpoet.PropertySpec
-import com.squareup.kotlinpoet.STAR
-import com.squareup.kotlinpoet.TypeName
-import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toKModifier
@@ -37,6 +28,7 @@ import com.squareup.kotlinpoet.ksp.toTypeName
 import toothpick.MemberInjector
 import toothpick.Scope
 import toothpick.compiler.common.generators.TPCodeGenerator
+import toothpick.compiler.common.generators.maybeStarParameterizedClassName
 import toothpick.compiler.common.generators.memberInjectorClassName
 import toothpick.compiler.common.generators.targets.VariableInjectionTarget
 import toothpick.compiler.common.generators.targets.getInvokeScopeGetMethodWithNameCodeBlock
@@ -62,7 +54,7 @@ internal class MemberInjectorGenerator(
         }
     }
 
-    private val parameterizedSourceClass: TypeName = sourceClass.maybeParameterizedClassName()
+    private val starParameterizedSourceClass: TypeName = sourceClass.maybeStarParameterizedClassName()
     val sourceClassName: ClassName = sourceClass.toClassName()
     val generatedClassName: ClassName = sourceClassName.memberInjectorClassName
 
@@ -73,7 +65,7 @@ internal class MemberInjectorGenerator(
                 .addOriginatingKSFile(sourceClass.containingFile!!)
                 .addModifiers(sourceClass.getVisibility().toKModifier() ?: KModifier.PUBLIC)
                 .addSuperinterface(
-                    MemberInjector::class.asClassName().parameterizedBy(parameterizedSourceClass)
+                    MemberInjector::class.asClassName().parameterizedBy(starParameterizedSourceClass)
                 )
                 .addAnnotation(
                     AnnotationSpec.builder(Suppress::class)
@@ -86,14 +78,6 @@ internal class MemberInjectorGenerator(
                 .emitInjectMethod(variableInjectionTargetList, methodInjectionTargetList)
                 .build()
         )
-    }
-
-    private fun KSClassDeclaration.maybeParameterizedClassName(): TypeName {
-        return if (this.typeParameters.isEmpty()) {
-            toClassName()
-        } else {
-            toClassName().parameterizedBy(this.typeParameters.map { STAR })
-        }
     }
 
     private fun TypeSpec.Builder.emitSuperMemberInjectorFieldIfNeeded(): TypeSpec.Builder = apply {
@@ -122,7 +106,7 @@ internal class MemberInjectorGenerator(
         addFunction(
             FunSpec.builder("inject")
                 .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
-                .addParameter("target", parameterizedSourceClass)
+                .addParameter("target", starParameterizedSourceClass)
                 .addParameter("scope", Scope::class)
                 .apply {
                     if (superClassThatNeedsInjection != null) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,10 +9,10 @@ inject = "javax.inject:javax.inject:1"
 junit4 = "junit:junit:4.13.2"
 kotlinpoet-core = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinpoet" }
-ksp = "com.google.devtools.ksp:symbol-processing-api:2.0.10-1.0.24"
+ksp = "com.google.devtools.ksp:symbol-processing-api:2.2.20-2.0.4"
 tp = "com.github.stephanenicolas.toothpick:toothpick:3.1.0"
 
 [plugins]
-kotlin = { id = "org.jetbrains.kotlin.jvm", version = "2.0.10" }
+kotlin = { id = "org.jetbrains.kotlin.jvm", version = "2.2.20" }
 kover = { id = "org.jetbrains.kotlinx.kover", version = "0.8.3" }
 spotless = { id = "com.diffplug.gradle.spotless", version = "6.2.0" }


### PR DESCRIPTION
Solves issue #32 . 

I have implemented support for basic generics for constructor- and member injection. It has been briefly tested in a fairly complex project with a lot of generic usage. It support any number of generic type parameters for the class that needs a factory or member-injector, as long as none of the generic types have more than one type constraint. (To support this one would probably need to rewrite the interface `toothpick.Factory<T>` in Toothpick.)

The changes are backwards compatible as proved by the unchanged unit tests - only new are added. 

## Examples of supported generics

-  `MyType<T>`
-  `MyType<T, U>`
-  `MyType<T> where T: Exception`
-  `MyType<T : Exception>`
-  `MyType<T, U: Exception>`

## Example of unsupported types
Any types with two or more constraints, like:

- `MyType<T> where T: Exception, T: Serializable` 
